### PR TITLE
Fixing a bug, forget to assign the credential.

### DIFF
--- a/Google-Gmail/Google.mail.DotNet/Google.mail.DotNet/GAAutentication.cs
+++ b/Google-Gmail/Google.mail.DotNet/Google.mail.DotNet/GAAutentication.cs
@@ -24,7 +24,7 @@ namespace Google.mail.DotNet
            
             try
             {
-               UserCredential credential = GoogleWebAuthorizationBroker.AuthorizeAsync(new ClientSecrets { ClientId = _client_id, ClientSecret = _client_secret },
+               result.credential = GoogleWebAuthorizationBroker.AuthorizeAsync(new ClientSecrets { ClientId = _client_id, ClientSecret = _client_secret },
                                                                          new[] {"https://mail.google.com/ email" },
                                                                          "Lindau",
                                                                          CancellationToken.None,

--- a/Google-Gmail/Google.mail.DotNet/Google.mail.DotNet/Program.cs
+++ b/Google-Gmail/Google.mail.DotNet/Google.mail.DotNet/Program.cs
@@ -15,9 +15,8 @@ namespace Google.mail.DotNet
             string _client_secret = "GeE-cD7PtraV0LqyoxqPnOpv";
 
             GAAutentication Autentication = GAAutentication.Autenticate(_client_id, _client_secret);
-            int i = 1;
 
-
+            Console.ReadKey();
         }
     }
 }


### PR DESCRIPTION
`result.credential` was always null and we never get the emails
